### PR TITLE
Implement Get Current User

### DIFF
--- a/src/routes/users-route.ts
+++ b/src/routes/users-route.ts
@@ -32,4 +32,22 @@ export const usersRoute = new Elysia({ prefix: '/api/users' })
             email: t.String({ format: 'email' }),
             password: t.String()
         })
+    })
+    .get('/current', async ({ headers, set }) => {
+        const authHeader = headers['authorization'];
+
+        if (!authHeader || !authHeader.startsWith('Bearer ')) {
+            set.status = 401;
+            return { error: "Unauthorized" };
+        }
+
+        const token = authHeader.split(' ')[1];
+        const result = await UsersService.getCurrentUser(token);
+
+        if (result.error) {
+            set.status = 401;
+            return result;
+        }
+
+        return result;
     });

--- a/src/services/users-service.ts
+++ b/src/services/users-service.ts
@@ -61,4 +61,25 @@ export class UsersService {
 
         return { data: token };
     }
+
+    static async getCurrentUser(token: string) {
+        // 1. Fetch session and user in one go
+        const result = await db.select({
+            id: users.id,
+            name: users.name,
+            email: users.email,
+            createdAt: users.createdAt
+        })
+        .from(sessions)
+        .innerJoin(users, eq(sessions.userId, users.id))
+        .where(eq(sessions.token, token));
+
+        const user = result[0];
+
+        if (!user) {
+            return { error: "Unauthorized" };
+        }
+
+        return { data: user };
+    }
 }


### PR DESCRIPTION
This PR adds the GET /api/users/current endpoint to fetch the profile of the currently logged-in user using a session token.